### PR TITLE
Fixes for schema_names and column_definition.null

### DIFF
--- a/activerecord6-redshift-adapter.gemspec
+++ b/activerecord6-redshift-adapter.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob(['LICENSE', 'README.md', 'lib/**/*.rb'])
   s.require_path = 'lib'
 
-  s.required_ruby_version = '>= 3.0'
+  s.required_ruby_version = '>= 2.7'
   s.add_runtime_dependency 'activerecord', '~> 7.0'
   s.add_runtime_dependency 'pg', '~> 1.0'
 end

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -154,7 +154,7 @@ module ActiveRecord
             default_value = extract_value_from_default(default)
             type_metadata = fetch_type_metadata(column_name, type, oid, fmod)
             default_function = extract_default_function(default_value, default)
-            new_column(column_name, default_value, type_metadata, notnull == 'f', table_name, default_function)
+            new_column(column_name, default_value, type_metadata, !notnull, table_name, default_function)
           end
         end
 

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -185,7 +185,7 @@ module ActiveRecord
 
         # Returns an array of schema names.
         def schema_names
-          select_value(<<-SQL, 'SCHEMA')
+          select_values(<<-SQL, 'SCHEMA')
             SELECT nspname
               FROM pg_namespace
              WHERE nspname !~ '^pg_.*'

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -762,8 +762,8 @@ module ActiveRecord
         coder_class.new(oid: row['oid'].to_i, name: row['typname'])
       end
 
-      def create_table_definition(*args) # :nodoc:
-        Redshift::TableDefinition.new(self, *args)
+      def create_table_definition(name, **options) # :nodoc:
+        Redshift::TableDefinition.new(self, name, **options)
       end
     end
   end


### PR DESCRIPTION
schema_names: need to use select_values to return all namespaces

column_definition: null was returning true, even though the underlying table was false